### PR TITLE
Fix get bids request bug

### DIFF
--- a/examples/get_bids.py
+++ b/examples/get_bids.py
@@ -31,4 +31,4 @@ def sample_get_bids():
 
 b = sample_get_bids()
 if b:
-    print('Found bids: {}'.format(len(b('bids'))))
+    print('Found bids: {}'.format(len(b['bids'])))

--- a/freelancersdk/resources/projects/projects.py
+++ b/freelancersdk/resources/projects/projects.py
@@ -212,7 +212,7 @@ def get_bids(session, project_ids=[], bid_ids=[], limit=10, offset=0):
     if bid_ids:
         get_bids_data['bids[]'] = bid_ids
     if project_ids:
-        get_bids_data['project_ids[]'] = project_ids
+        get_bids_data['projects[]'] = project_ids
     get_bids_data['limit'] = limit
     get_bids_data['offset'] = offset
     # GET /api/projects/0.1/bids/

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -502,9 +502,10 @@ class TestProjects(unittest.TestCase):
         j = get_bids(self.session, **get_bids_data)
         get_bids_data.update({'projects[]': get_bids_data['project_ids']})
         del(get_bids_data['project_ids'])
-        self.assertTrue(self.session.session.get.called)
-        self.assertTrue(self.session.session.get.call_args[1]['params']['offset'], 10)
-        self.assertTrue(self.session.session.get.call_args[1]['params']['offset'], 20)
+        self.session.session.get.assert_called_once_with(
+            'https://fake-fln.com/api/projects/0.1/bids/',
+            params=get_bids_data,
+            verify=True)
         self.assertEquals(len(j['bids']), 5)
 
     def test_award_project_bid(self):


### PR DESCRIPTION
Fixes #16 , and fixes #11 
This PR replaces the `project_ids[]` parameter in the `get_bids()` method with the correct parameter name, `projects[]`. `examples/get_bids.py` is also fixed to access the `bids` dictionary correctly.

