### PR TITLE
Fix compact parameter not setting correctly

### DIFF
--- a/examples/search_freelancers.py
+++ b/examples/search_freelancers.py
@@ -14,17 +14,14 @@ def sample_search_freelancers():
     oauth_token = os.environ.get('FLN_OAUTH_TOKEN')
     session = Session(oauth_token=oauth_token, url=url)
     user_details = create_get_users_details_object(
-        avatar=True,
-        reputation=True,
-        reputation_extra=True,
-        profile_description=True,
+        country=True,
+        profile_description=True
     )
     try:
         result = search_freelancers(
             session,
             username='CodeJunk',
-            user_details=user_details,
-            compact=False
+            user_details=user_details
         )
     except UsersNotFoundException as e:
         print('Error message: {}'.format(e.message))
@@ -36,4 +33,4 @@ def sample_search_freelancers():
 result = sample_search_freelancers()
 
 if result:
-    print('Found freelancers: {}'.format(result))
+    print('Found freelancers: {}'.format(len(result)))

--- a/examples/search_freelancers.py
+++ b/examples/search_freelancers.py
@@ -14,14 +14,17 @@ def sample_search_freelancers():
     oauth_token = os.environ.get('FLN_OAUTH_TOKEN')
     session = Session(oauth_token=oauth_token, url=url)
     user_details = create_get_users_details_object(
-        country=True,
-        profile_description=True
+        avatar=True,
+        reputation=True,
+        reputation_extra=True,
+        profile_description=True,
     )
     try:
         result = search_freelancers(
             session,
             username='CodeJunk',
-            user_details=user_details
+            user_details=user_details,
+            compact=False
         )
     except UsersNotFoundException as e:
         print('Error message: {}'.format(e.message))
@@ -33,4 +36,4 @@ def sample_search_freelancers():
 result = sample_search_freelancers()
 
 if result:
-    print('Found freelancers: {}'.format(len(result)))
+    print('Found freelancers: {}'.format(result))

--- a/freelancersdk/resources/users/users.py
+++ b/freelancersdk/resources/users/users.py
@@ -155,8 +155,9 @@ def search_freelancers(
         search_freelancers_data['ratings'] = ratings
     if user_details:
         search_freelancers_data.update(user_details)
-
-    search_freelancers_data['compact'] = compact
+    if compact:
+        search_freelancers_data['compact'] = compact
+    
     search_freelancers_data['limit'] = limit
     search_freelancers_data['offset'] = offset
     

--- a/freelancersdk/resources/users/users.py
+++ b/freelancersdk/resources/users/users.py
@@ -157,7 +157,7 @@ def search_freelancers(
         search_freelancers_data.update(user_details)
     if compact:
         search_freelancers_data['compact'] = compact
-    
+
     search_freelancers_data['limit'] = limit
     search_freelancers_data['offset'] = offset
     


### PR DESCRIPTION
The `compact` parameter in `search_freelancers` returns a compact version of the query regardless of whether it is set to `True` or `False`. Fixes the issue by setting the `compact` key only if the argument is set to `True`.