### PR TITLE
Fix search_freelancer parameters

### DIFF
--- a/examples/search_freelancers.py
+++ b/examples/search_freelancers.py
@@ -14,14 +14,15 @@ def sample_search_freelancers():
     oauth_token = os.environ.get('FLN_OAUTH_TOKEN')
     session = Session(oauth_token=oauth_token, url=url)
     user_details = create_get_users_details_object(
-        country=True,
-        profile_description=True
+        cover_image=True,
+        reputation=True,
+        display_info=True
     )
     try:
         result = search_freelancers(
             session,
-            username='CodeJunk',
-            user_details=user_details
+            query='design',
+            user_details=user_details,
         )
     except UsersNotFoundException as e:
         print('Error message: {}'.format(e.message))
@@ -33,4 +34,4 @@ def sample_search_freelancers():
 result = sample_search_freelancers()
 
 if result:
-    print('Found freelancers: {}'.format(len(result)))
+    print('Found freelancers: {}'.format(result))

--- a/freelancersdk/resources/users/users.py
+++ b/freelancersdk/resources/users/users.py
@@ -120,7 +120,7 @@ def search_freelancers(
                         session,
                         jobs=None, 
                         countries=None,
-                        username=None,
+                        query=None,
                         hourly_rate_min=None,
                         hourly_rate_max=None,
                         online_only=None,
@@ -137,8 +137,8 @@ def search_freelancers(
         search_freelancers_data['jobs[]'] = jobs
     if countries:
         search_freelancers_data['countries[]'] = countries
-    if username:
-        search_freelancers_data['username'] = username
+    if query:
+        search_freelancers_data['query'] = query
     if hourly_rate_min:
         search_freelancers_data['hourly_rate_min'] = hourly_rate_min
     if hourly_rate_max:
@@ -160,7 +160,6 @@ def search_freelancers(
 
     search_freelancers_data['limit'] = limit
     search_freelancers_data['offset'] = offset
-    
     response = make_get_request(
         session, 'users/directory',
         params_data=search_freelancers_data

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -79,7 +79,7 @@ class FakeSearchFreelancersGetResponse:
                     '100': {
                         'status': None,
                         'id': 100,
-                        'username': 'freelancer123'
+                        'username': 'creativedesign'
                     }
                 }
             }
@@ -333,7 +333,7 @@ class TestUsers(unittest.TestCase):
         self.session.session.get.return_value = FakeSearchFreelancersGetResponse()
 
         search_freelancers_data = {
-            'username': 'freelancer123',
+            'query': 'designer',
             'limit': 10,
             'offset': 0,
             'compact': True,
@@ -346,7 +346,7 @@ class TestUsers(unittest.TestCase):
 
         result = search_freelancers(
             self.session,
-            username='freelancer123',
+            query='designer',
             user_details=user_details
         )
 


### PR DESCRIPTION
The `search_freelancer` endpoint takes in a `query` param, not a `username`. This patches the appropriate fix as well as the corresponding unit test.