### PR TITLE
Add search projects projections

### DIFF
--- a/examples/search_projects.py
+++ b/examples/search_projects.py
@@ -2,6 +2,11 @@ from freelancersdk.session import Session
 from freelancersdk.resources.projects.projects import search_projects
 from freelancersdk.resources.projects.exceptions import \
     ProjectsNotFoundException
+from freelancersdk.resources.projects.helpers import (
+    create_search_projects_filter,
+    create_get_projects_user_details_object,
+    create_get_projects_project_details_object,
+)
 import os
 
 
@@ -10,16 +15,19 @@ def sample_search_projects():
     oauth_token = os.environ.get('FLN_OAUTH_TOKEN')
     session = Session(oauth_token=oauth_token, url=url)
 
-    search_data = {
-        'query': 'logo',
-        'project_types': 'fixed',
-        'limit': 10,
-        'offset': 0,
-        'active_only': True,
-    }
+    query = 'Logo Design'
+    search_filter = create_search_projects_filter(
+        sort_field= 'time_updated',
+        or_search_query= True,
+    )
 
     try:
-        p = search_projects(session, **search_data)
+        p = search_projects(
+            session,
+            query=query,
+            search_filter=search_filter
+        )
+
     except ProjectsNotFoundException as e:
         print('Error message: {}'.format(e.message))
         print('Server response: {}'.format(e.error_code))
@@ -30,4 +38,4 @@ def sample_search_projects():
 
 p = sample_search_projects()
 if p:
-    print('Found projects: {}'.format(p('total_count')))
+    print('Found projects: {}'.format(p))

--- a/freelancersdk/resources/projects/helpers.py
+++ b/freelancersdk/resources/projects/helpers.py
@@ -360,3 +360,66 @@ def create_get_projects_object(project_ids=None, owner_ids=None, seo_urls=None,
         p.update(offset=offset)
 
     return p
+
+
+def create_search_projects_filter(
+                                project_upgrades=None,
+                                contest_upgrades=None,
+                                or_search_query=None,
+                                project_types=None,
+                                include_contests=None,
+                                min_avg_price=None,
+                                max_avg_price=None,
+                                min_avg_hourly_rate=None,
+                                max_avg_hourly_rate=None,
+                                jobs=None,
+                                countries=None,
+                                languages=None,
+                                from_time=None,
+                                to_time=None,
+                                sort_field=None,
+                                reverse_sort=None,
+                                highlight_pre_tags=None,
+                                highlight_post_tags=None,
+                                ):
+    
+    p = {}
+
+    if project_upgrades:
+        p.update({'project_upgrades[]': project_upgrades})
+    if contest_upgrades:
+        p.update({'contest_upgrades[]': contest_upgrades})
+    if project_types:
+        p.update({'project_types[]': project_types})
+    if jobs:
+        p.update({'jobs[]': jobs})
+    if countries:
+        p.update({'countries[]': countries})
+    if languages:
+        p.update({'languages[]': languages})
+    if or_search_query:
+        p.update(or_search_query=or_search_query)
+    if min_avg_price:
+        p.update(min_avg_price=min_avg_price)
+    if max_avg_price:
+        p.update(max_avg_price=max_avg_price)
+    if min_avg_hourly_rate:
+        p.update(min_avg_hourly_rate=min_avg_hourly_rate)
+    if max_avg_hourly_rate:
+        p.update(max_avg_hourly_rate=max_avg_hourly_rate)
+    if include_contests:
+        p.update(include_contests=include_contests)
+    if to_time:
+        p.update(to_time=to_time)
+    if from_time:
+        p.update(from_time=from_time)
+    if sort_field:
+        p.update(sort_field=sort_field)
+    if reverse_sort:
+        p.update(reverse_sort=reverse_sort)
+    if highlight_pre_tags:
+        p.update(highlight_pre_tags=highlight_pre_tags)
+    if highlight_post_tags:
+        p.update(highlight_post_tags=highlight_post_tags)
+    
+    return p

--- a/freelancersdk/resources/projects/projects.py
+++ b/freelancersdk/resources/projects/projects.py
@@ -180,17 +180,29 @@ def get_project_by_id(session, project_id, project_details=None, user_details=No
             message=json_data['message'], error_code=json_data['error_code']
         )
 
-def search_projects(session, query, project_types, limit, offset,
+def search_projects(session, 
+                    query,
+                    search_filter=None,
+                    project_details=None,
+                    user_details=None,
+                    limit=10,
+                    offset=0,
                     active_only=None):
     """
     Search for all projects
     """
     search_data = {
         'query': query,
-        'project_types': project_types,
         'limit': limit,
         'offset': offset,
     }
+    if search_filter:
+        search_data.update(search_filter)
+    if project_details:
+        search_data.update(project_details)
+    if user_details:
+        search_data.update(user_details)
+
     # GET /api/projects/0.1/projects/all/
     # GET /api/projects/0.1/projects/active/
     endpoint = 'projects/{}'.format('active' if active_only else 'all')


### PR DESCRIPTION
Solves #38. Solves #37.

Adds all missing projections and filters to the `search_projects` endpoint. Created helpers for building the projections and filters for the function. Also updates unit tests and examples.