### PR TITLE
Add request id to contests exceptions

### DIFF
--- a/freelancersdk/resources/contests/contests.py
+++ b/freelancersdk/resources/contests/contests.py
@@ -30,4 +30,5 @@ def create_contest(session, title, description, type, duration, job_ids, currenc
         return Contest(json_data['result'])
     else:
         raise ContestNotCreatedException(message=json_data['message'],
-                                         error_code=json_data['error_code'])
+                                         error_code=json_data['error_code'],
+                                         request_id=json_data['request_id'])

--- a/freelancersdk/resources/contests/exceptions.py
+++ b/freelancersdk/resources/contests/exceptions.py
@@ -2,6 +2,8 @@ class ContestNotCreatedException(Exception):
     """
     Contest could not be created
     """
-    def __init__(self, message, error_code):
+
+    def __init__(self, message, error_code, request_id):
         super(ContestNotCreatedException, self).__init__(message)
         self.error_code = error_code
+        self.request_id = request_id


### PR DESCRIPTION
Adds the `request_id` field to contests exceptions.