### PR TITLE
Bump Jinja2 and SQLAlchemy

### DIFF
--- a/examples/demo_web_application/requirements.txt
+++ b/examples/demo_web_application/requirements.txt
@@ -7,7 +7,7 @@ Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.3.2
 idna==2.6
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 Mako==1.0.7
 MarkupSafe==1.0
 psycopg2==2.7.3.2
@@ -15,7 +15,7 @@ python-dateutil==2.6.1
 python-editor==1.0.3
 requests==2.20.0
 six==1.11.0
-SQLAlchemy==1.1.15
+SQLAlchemy==1.3.0
 urllib3==1.24.2
 Werkzeug==0.12.2
 freelancersdk


### PR DESCRIPTION
Bump Jinja2 to `2.10.1` and SQLAlchemy to `1.3.0`. Confirmed the upgrades are compatible.